### PR TITLE
Changes to CMakeLists for NAG compiler and shortening a line

### DIFF
--- a/doc/source/Decomp.txt
+++ b/doc/source/Decomp.txt
@@ -42,8 +42,7 @@ only one IO task.  Since this technique does not guarantee that data
 on the IO node represents a contiguous block of data on the file it
 may require multiple calls to the underlying (NetCDF) IO library.
 
-As an example suppose we have a global two dimensional grid of size 4x5 decomposed over 5 tasks. We represent the 
-two dimensional grid in terms of offset from the initial element ie
+As an example suppose we have a global two dimensional grid of size 4x5 decomposed over 5 tasks. We represent the two dimensional grid in terms of offset from the initial element ie
 <pre>
      0  1  2  3 
      4  5  6  7 

--- a/doc/source/Installing.txt
+++ b/doc/source/Installing.txt
@@ -112,7 +112,7 @@ Once the tests have been built, you may run tests with:
     > ctest
 
 
-_If you have not run `make tests` before you run `ctest`, then you will see
+_Note: If you have not run `make tests` before you run `ctest`, then you will see
 all of the tests fail._
 
 Alternatively, you may build the test executables and then run tests 
@@ -124,7 +124,7 @@ immediately with:
 
 (similar to the typical `make check` Autotools target).
 
-*NOTE:* These tests are designed to run in parallel.
+*ANOTHER NOTE:* These tests are designed to run in parallel.
 If you are on one of the supported supercomputing platforms (i.e., NERSC, NWSC, ALCF, 
 etc.), then the `ctest` command will assume that the tests will be run in an appropriately configured and scheduled parallel job.  This can be done by requesting an interactive session from the login nodes and then running `ctest` from within the interactive terminal.  Alternatively, this can be done by running the `ctest` command from a job submission script.  It is important to understand, however, that `ctest` itself will preface all of the test executable commands with the appropriate `mpirun`/`mpiexec`/`runjob`/etc. Hence, you should not further preface the `ctest` command with these MPI launchers.
 

--- a/src/flib/CMakeLists.txt
+++ b/src/flib/CMakeLists.txt
@@ -51,6 +51,9 @@ target_compile_definitions (piof
 if ("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "GNU")
     target_compile_options (piof
         PRIVATE -ffree-line-length-none)
+elseif (CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
+   target_compile_options (piof
+       PUBLIC -mismatch_all)
 endif()
 
 # Look for c_sizeof capability

--- a/src/gptl/CMakeLists.txt
+++ b/src/gptl/CMakeLists.txt
@@ -44,6 +44,11 @@ endif ()
 target_compile_definitions (gptl
     PUBLIC ${CMAKE_Fortran_COMPILER_DIRECTIVE})
 
+if (CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
+   target_compile_options (gptl
+       PUBLIC -mismatch_all)
+endif ()
+
 #==============================================================================
 #  DEFINE THE INSTALL
 #==============================================================================

--- a/tests/performance/pioperformance.F90
+++ b/tests/performance/pioperformance.F90
@@ -308,7 +308,8 @@ contains
 #ifdef VARDOUBLE
                    nvarmult = nvarmult+2
 #endif
-                   print *, 'write ',rearr_name(rearr), varsize, ntasks, nvars, nvarmult*nvars*nframes*gmaplen*4.0/(1048576.0*wall(2))
+                   print *, 'write ',rearr_name(rearr), varsize, ntasks, nvars, &
+                                     nvarmult*nvars*nframes*gmaplen*4.0/(1048576.0*wall(2))
 #ifdef BGQTRY
   call print_memusage()
 #endif


### PR DESCRIPTION
Looks like I only had one of the two lines that needed shortening in my commit yesterday. This pull request has the other, plus the added -mismatch_all flag for the NAG compiler. My testing today indicated that these changes helped get the basic tests to run through and pass. I will update the issue post!