### PR TITLE
Changing the C-generated code command to include dependencies on templates

### DIFF
--- a/src/clib/CMakeLists.txt
+++ b/src/clib/CMakeLists.txt
@@ -160,7 +160,9 @@ if (PnetCDF_C_FOUND AND NetCDF_C_FOUND AND PIO_GENERATE_SOURCES_FROM_TEMPLATES)
     # Find perl
     find_package (Perl REQUIRED)
     if (Perl_FOUND)
-        add_custom_target (gennc
+        add_custom_command (OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/pio_put_nc.c
+                                   ${CMAKE_CURRENT_BINARY_DIR}/pio_get_nc.c
+                                   ${CMAKE_CURRENT_BINARY_DIR}/pio_nc.c
             COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/pio_c_put_template.c
                                              ${CMAKE_CURRENT_BINARY_DIR}/pio_c_put_template.c
             COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/pio_c_get_template.c
@@ -188,7 +190,9 @@ if (PnetCDF_C_FOUND AND NetCDF_C_FOUND AND PIO_GENERATE_SOURCES_FROM_TEMPLATES)
     
 # If both NetCDF and PnetCDF are NOT found, then just copy existing source files
 else ()
-        add_custom_target (gennc
+        add_custom_command (OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/pio_put_nc.c
+                                   ${CMAKE_CURRENT_BINARY_DIR}/pio_get_nc.c
+                                   ${CMAKE_CURRENT_BINARY_DIR}/pio_nc.c
             COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/pio_put_nc.c
                                              ${CMAKE_CURRENT_BINARY_DIR}/pio_put_nc.c
             COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/pio_get_nc.c
@@ -203,7 +207,6 @@ else ()
                     ${CMAKE_CURRENT_SOURCE_DIR}/pio_get_nc.c
                     ${CMAKE_CURRENT_SOURCE_DIR}/pio_nc.c)
 endif ()
-add_dependencies (pioc gennc)
 
 
 #===== Check for necessities =====

--- a/src/clib/CMakeLists.txt
+++ b/src/clib/CMakeLists.txt
@@ -6,21 +6,22 @@ project (PIOC C)
 #  DEFINE THE TARGET
 #==============================================================================
 
-set (PIO_C_SRCS ${CMAKE_CURRENT_SOURCE_DIR}/topology.c
-                ${CMAKE_CURRENT_BINARY_DIR}/pio_nc.c
-                ${CMAKE_CURRENT_SOURCE_DIR}/pio_file.c
-                ${CMAKE_CURRENT_SOURCE_DIR}/pioc_support.c
-                ${CMAKE_CURRENT_SOURCE_DIR}/pio_lists.c
-                ${CMAKE_CURRENT_SOURCE_DIR}/pioc.c
-                ${CMAKE_CURRENT_SOURCE_DIR}/pioc_sc.c
-                ${CMAKE_CURRENT_SOURCE_DIR}/pio_spmd.c
-                ${CMAKE_CURRENT_SOURCE_DIR}/pio_rearrange.c
-                ${CMAKE_CURRENT_SOURCE_DIR}/pio_darray.c
-                ${CMAKE_CURRENT_BINARY_DIR}/pio_put_nc.c 
-                ${CMAKE_CURRENT_BINARY_DIR}/pio_get_nc.c
-                ${CMAKE_CURRENT_SOURCE_DIR}/bget.c)
+set (PIO_C_SRCS topology.c
+                pio_file.c
+                pioc_support.c
+                pio_lists.c
+                pioc.c
+                pioc_sc.c
+                pio_spmd.c
+                pio_rearrange.c
+                pio_darray.c
+                bget.c)
 
-add_library (pioc ${PIO_C_SRCS})
+set (PIO_GENNC_SRCS ${CMAKE_CURRENT_BINARY_DIR}/pio_nc.c
+                    ${CMAKE_CURRENT_BINARY_DIR}/pio_put_nc.c 
+                    ${CMAKE_CURRENT_BINARY_DIR}/pio_get_nc.c)
+
+add_library (pioc ${PIO_C_SRCS} ${PIO_GENNC_SRCS})
 
 # Include the clib source directory
 target_include_directories (pioc
@@ -160,20 +161,17 @@ if (PnetCDF_C_FOUND AND NetCDF_C_FOUND AND PIO_GENERATE_SOURCES_FROM_TEMPLATES)
     # Find perl
     find_package (Perl REQUIRED)
     if (Perl_FOUND)
-        add_custom_command (OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/pio_put_nc.c
-                                   ${CMAKE_CURRENT_BINARY_DIR}/pio_get_nc.c
-                                   ${CMAKE_CURRENT_BINARY_DIR}/pio_nc.c
+        add_custom_command (OUTPUT ${PIO_GENNC_SRCS}
             COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/pio_c_put_template.c
-                                             ${CMAKE_CURRENT_BINARY_DIR}/pio_c_put_template.c
+                                             pio_c_put_template.c
             COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/pio_c_get_template.c
-                                             ${CMAKE_CURRENT_BINARY_DIR}/pio_c_get_template.c
+                                             pio_c_get_template.c
             COMMAND ${PERL_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/ncputgetparser.pl 
                                        ${NetCDF_C_INCLUDE_DIR} ${PnetCDF_C_INCLUDE_DIR}
             COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/pio_c_template.c
-                                             ${CMAKE_CURRENT_BINARY_DIR}/pio_c_template.c
+                                             pio_c_template.c
             COMMAND ${PERL_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/ncparser.pl
                                        ${NetCDF_C_INCLUDE_DIR} ${PnetCDF_C_INCLUDE_DIR}
-            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
             DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/pio_c_put_template.c
                     ${CMAKE_CURRENT_SOURCE_DIR}/pio_c_get_template.c
                     ${CMAKE_CURRENT_SOURCE_DIR}/ncputgetparser.pl
@@ -185,16 +183,13 @@ if (PnetCDF_C_FOUND AND NetCDF_C_FOUND AND PIO_GENERATE_SOURCES_FROM_TEMPLATES)
     
 # If both NetCDF and PnetCDF are NOT found, then just copy existing source files
 else ()
-        add_custom_command (OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/pio_put_nc.c
-                                   ${CMAKE_CURRENT_BINARY_DIR}/pio_get_nc.c
-                                   ${CMAKE_CURRENT_BINARY_DIR}/pio_nc.c
+        add_custom_command (OUTPUT ${PIO_GENNC_SRCS}
             COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/pio_put_nc.c
-                                             ${CMAKE_CURRENT_BINARY_DIR}/pio_put_nc.c
+                                             pio_put_nc.c
             COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/pio_get_nc.c
-                                             ${CMAKE_CURRENT_BINARY_DIR}/pio_get_nc.c
+                                             pio_get_nc.c
             COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/pio_nc.c
-                                             ${CMAKE_CURRENT_BINARY_DIR}/pio_nc.c
-            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+                                             pio_nc.c
             DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/pio_put_nc.c
                     ${CMAKE_CURRENT_SOURCE_DIR}/pio_get_nc.c
                     ${CMAKE_CURRENT_SOURCE_DIR}/pio_nc.c)

--- a/src/clib/CMakeLists.txt
+++ b/src/clib/CMakeLists.txt
@@ -178,11 +178,6 @@ if (PnetCDF_C_FOUND AND NetCDF_C_FOUND AND PIO_GENERATE_SOURCES_FROM_TEMPLATES)
                     ${CMAKE_CURRENT_SOURCE_DIR}/pio_c_get_template.c
                     ${CMAKE_CURRENT_SOURCE_DIR}/ncputgetparser.pl
                     ${CMAKE_CURRENT_SOURCE_DIR}/pio_c_template.c
-                    ${CMAKE_CURRENT_SOURCE_DIR}/ncparser.pl
-            SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/pio_c_put_template.c
-                    ${CMAKE_CURRENT_SOURCE_DIR}/pio_c_get_template.c
-                    ${CMAKE_CURRENT_SOURCE_DIR}/ncputgetparser.pl
-                    ${CMAKE_CURRENT_SOURCE_DIR}/pio_c_template.c
                     ${CMAKE_CURRENT_SOURCE_DIR}/ncparser.pl)
     else ()
         message (FATAL_ERROR "Need Perl to create PIO C source files from templates")
@@ -201,9 +196,6 @@ else ()
                                              ${CMAKE_CURRENT_BINARY_DIR}/pio_nc.c
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
             DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/pio_put_nc.c
-                    ${CMAKE_CURRENT_SOURCE_DIR}/pio_get_nc.c
-                    ${CMAKE_CURRENT_SOURCE_DIR}/pio_nc.c
-            SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/pio_put_nc.c
                     ${CMAKE_CURRENT_SOURCE_DIR}/pio_get_nc.c
                     ${CMAKE_CURRENT_SOURCE_DIR}/pio_nc.c)
 endif ()

--- a/src/clib/CMakeLists.txt
+++ b/src/clib/CMakeLists.txt
@@ -160,7 +160,7 @@ if (PnetCDF_C_FOUND AND NetCDF_C_FOUND AND PIO_GENERATE_SOURCES_FROM_TEMPLATES)
     # Find perl
     find_package (Perl REQUIRED)
     if (Perl_FOUND)
-        execute_process (
+        add_custom_target (gennc
             COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/pio_c_put_template.c
                                              ${CMAKE_CURRENT_BINARY_DIR}/pio_c_put_template.c
             COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/pio_c_get_template.c
@@ -171,22 +171,39 @@ if (PnetCDF_C_FOUND AND NetCDF_C_FOUND AND PIO_GENERATE_SOURCES_FROM_TEMPLATES)
                                              ${CMAKE_CURRENT_BINARY_DIR}/pio_c_template.c
             COMMAND ${PERL_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/ncparser.pl
                                        ${NetCDF_C_INCLUDE_DIR} ${PnetCDF_C_INCLUDE_DIR}
-            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+            DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/pio_c_put_template.c
+                    ${CMAKE_CURRENT_SOURCE_DIR}/pio_c_get_template.c
+                    ${CMAKE_CURRENT_SOURCE_DIR}/ncputgetparser.pl
+                    ${CMAKE_CURRENT_SOURCE_DIR}/pio_c_template.c
+                    ${CMAKE_CURRENT_SOURCE_DIR}/ncparser.pl
+            SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/pio_c_put_template.c
+                    ${CMAKE_CURRENT_SOURCE_DIR}/pio_c_get_template.c
+                    ${CMAKE_CURRENT_SOURCE_DIR}/ncputgetparser.pl
+                    ${CMAKE_CURRENT_SOURCE_DIR}/pio_c_template.c
+                    ${CMAKE_CURRENT_SOURCE_DIR}/ncparser.pl)
     else ()
         message (FATAL_ERROR "Need Perl to create PIO C source files from templates")
     endif ()
     
 # If both NetCDF and PnetCDF are NOT found, then just copy existing source files
 else ()
-        execute_process (
+        add_custom_target (gennc
             COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/pio_put_nc.c
                                              ${CMAKE_CURRENT_BINARY_DIR}/pio_put_nc.c
             COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/pio_get_nc.c
                                              ${CMAKE_CURRENT_BINARY_DIR}/pio_get_nc.c
             COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/pio_nc.c
                                              ${CMAKE_CURRENT_BINARY_DIR}/pio_nc.c
-            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+            DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/pio_put_nc.c
+                    ${CMAKE_CURRENT_SOURCE_DIR}/pio_get_nc.c
+                    ${CMAKE_CURRENT_SOURCE_DIR}/pio_nc.c
+            SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/pio_put_nc.c
+                    ${CMAKE_CURRENT_SOURCE_DIR}/pio_get_nc.c
+                    ${CMAKE_CURRENT_SOURCE_DIR}/pio_nc.c)
 endif ()
+add_dependencies (pioc gennc)
 
 
 #===== Check for necessities =====


### PR DESCRIPTION
This branch implements a change to include the C-template code, used to generate the 'pio_nc.c', 'pio_put_nc.c' and 'pio_get_nc.c' files when generating C-code from templates, as dependencies for the 'pioc' library. 

Originally, the 'execute_process' command was used to copy these 3 files from the CMAKE_CURRENT_SOURCE_DIR to the CMAKE_CURRENT_BINARY_DIR before building (and the 'pioc' library depended on the CMAKE_BINARY_DIR location of these files).  Unfortunately, the 'execute_process' command does not properly recognize the original files (in the SOURCE dir) as dependencies for the copied files.  Thus, changes to the files in the SOURCE dir were not recopied to the BINARY dir when building.

Fortunately, this type of template-based code generation is done in the 'piof' library with genf90, and the trick is to use the 'add_custom_command' command, instead of the 'execute_process' command.  The 'add_custom_command' can be used to accomplish the same thing as the 'execute_process' command, except for 2 important aspects:

1) The 'add_custom_command' command associates the SOURCE files as dependencies for the (generated) BINARY files, which are in turn dependencies for the 'pioc' library.  Hence, changes to the SOURCE files are recognized by CMake to trigger the source-code generation before attempting to rebuild pioc.  That fixes the problem!

2) The 'add_custom_command' command is executed at build time, while the 'execute_process' command is executed at configure time.  This doesn't create a problem for us, however, as long as the dependencies are properly satisfied.