### PR TITLE
NERSC removed the cce/8.4.0.219 module we were using and replaced it …

### DIFF
--- a/ctest/runcdash-nersc-cray.sh
+++ b/ctest/runcdash-nersc-cray.sh
@@ -12,7 +12,7 @@ module load PrgEnv-cray
 module load craype-ivybridge
 module load cray-shmem
 module load cray-mpich
-module swap cce cce/8.4.0.219
+module swap cce cce/8.4.0.223
 module load torque
 module load git/2.4.6 
 module load cmake/3.0.0


### PR DESCRIPTION
…with cce/8.4.0.223. I updated runcdash-nersc-cray.sh so our nightly tests will build and run again.